### PR TITLE
feat: use github.action_path in working-directory and check for successful start

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -4,18 +4,12 @@ branding:
   icon: "user-check"
   color: "blue"
 inputs:
-  FUSIONAUTH_VERSION:
-    description: "FusionAuth version number"
-    default: "latest"
-  DATABASE_USERNAME:
-    description: "Database username used by FusionAuth"
-    default: fusionauth
   DATABASE_PASSWORD:
     description: "Database password used by FusionAuth"
     default: hkaLBM3RVnyYeYeqE3WI1w2e4Avpy0Wd5O3s3
   FUSIONAUTH_APP_KICKSTART_DIRECTORY_PATH:
     description: "Where your kickstart file and related include files live, relative to the checked out directory. If not provided, a default kickstart will be used."
-    default: 
+    default:
   FUSIONAUTH_APP_KICKSTART_FILENAME:
     description: "The name of your kickstart file in FUSIONAUTH_APP_KICKSTART_DIRECTORY_PATH, otherwise this is ignored."
     default: "kickstart.json"
@@ -25,6 +19,16 @@ inputs:
   FUSIONAUTH_APP_RUNTIME_MODE:
     description: "FusionAuth application runtime mode"
     default: development
+  DATABASE_USERNAME:
+    description: "Database username used by FusionAuth"
+    default: fusionauth
+  FUSIONAUTH_URL:
+    description: 'The FusionAuth URL.'
+    required: false
+    default: 'http://localhost:9011'
+  FUSIONAUTH_VERSION:
+    description: "FusionAuth version number"
+    default: "latest"
   OPENSEARCH_JAVA_OPTS:
     description: "Opensearch configuration"
     default: '"-Xms512m -Xmx512m"'
@@ -37,24 +41,37 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - name: Get docker-compose.yaml
-      uses: actions/checkout@v4
-      with:
-        repository: 'fusionauth/fusionauth-github-action'
-        path: 'faDockerComposeFilePath'
+    - name: Action Path
+      run: echo $ACTION_PATH
+      env:
+        ACTION_PATH: ${{ github.action_path }}
+      shell: bash
+
+    - name: Action Repository
+      run: echo $ACTION_REPOSITORY
+      env:
+        ACTION_PATH: ${{ github.action_repository }}
+      shell: bash
+
+    - name: Action Ref
+      run: echo $ACTION_REF
+      env:
+        ACTION_PATH: ${{ github.action_ref }}
+      shell: bash
 
     - name: Process kickstart inputs
       run: scripts/copy-kickstart.sh
-      working-directory: faDockerComposeFilePath
+      working-directory: ${{ github.action_path }}
       env:
         FUSIONAUTH_APP_KICKSTART_FILENAME: ${{ inputs.FUSIONAUTH_APP_KICKSTART_FILENAME }}
         FUSIONAUTH_APP_KICKSTART_DIRECTORY_PATH: ${{ inputs.FUSIONAUTH_APP_KICKSTART_DIRECTORY_PATH }}
         GH_WORKSPACE_PATH: ${{ github.workspace }}
       shell: bash
+
     - name: Start FusionAuth
       run: docker compose up -d # -d in background
       shell: bash
-      working-directory: faDockerComposeFilePath
+      working-directory: ${{ github.action_path }}
       env:
         POSTGRES_USER: ${{ inputs.POSTGRES_USER }}
         POSTGRES_PASSWORD: ${{ inputs.POSTGRES_PASSWORD }}
@@ -65,6 +82,22 @@ runs:
         FUSIONAUTH_APP_KICKSTART_FILE: /usr/local/fusionauth/kickstart/kickstart.json
         OPENSEARCH_JAVA_OPTS: ${{ inputs.OPENSEARCH_JAVA_OPTS }}
         FUSIONAUTH_VERSION: ${{ inputs.FUSIONAUTH_VERSION }}
+
+    # Check FusionAuth status 5 times with increasing wait times.
+    # Continue if FusionAuth status is OK or fail at the end.
+    - name: Check FusionAuth status
+      run: |
+        for i in {1..5}; do
+          if curl -s ${{ inputs.FUSIONAUTH_URL }}/api/status | grep -qi "ok"; then
+            echo "FusionAuth is up and running."
+            exit 0
+          else
+            echo "FusionAuth is not up and running. Waiting for $(expr 5 \* $i) seconds."
+            sleep $(expr 5 \* $i)
+          fi
+        done
+        exit 1
+      shell: bash
 
 # Start each service individually for testing instead:
 


### PR DESCRIPTION
This addresses #3 and #4.

- fix: use github.action_path in working-directory to properly bound to used action tag
- feat: add Check FusionAuth status to exit successfully or failed

Here an example run:
https://github.com/sonderformat-llc/quickstart-nextjs-e2e-test-prototype/actions/runs/12466169853/job/34793210589
